### PR TITLE
chore: whitelist js-waku dogfooding origin for CORS

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"log"
-	"net/http"
 	"time"
 
 	"github.com/status-im/dev-telemetry/telemetry"
@@ -51,7 +50,7 @@ func main() {
 		AllowedHeaders: []string{"*"},
 	})
 
-	http.Handle("/", corsHandler.Handler(server.Handler()))
+	server.Router.Use(corsHandler.Handler)
 
 	server.Start(*port)
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,12 +3,14 @@ package main
 import (
 	"flag"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/status-im/dev-telemetry/telemetry"
 	"go.uber.org/zap"
 
 	"github.com/robfig/cron/v3"
+	"github.com/rs/cors"
 )
 
 func main() {
@@ -42,5 +44,14 @@ func main() {
 	defer c.Stop()
 
 	server := telemetry.NewServer(db, logger)
+
+	corsHandler := cors.New(cors.Options{
+		AllowedOrigins: []string{"https://lab.waku.org"},
+		AllowedMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
+		AllowedHeaders: []string{"*"},
+	})
+
+	http.Handle("/", corsHandler.Handler(server.Handler()))
+
 	server.Start(*port)
 }

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rs/cors v1.11.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -965,6 +965,8 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rs/cors v1.11.0 h1:0B9GE/r9Bc2UxRMMtymBkHTenPkHDv0CW4Y98GBY+po=
+github.com/rs/cors v1.11.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=


### PR DESCRIPTION
The dogfooding app for js-waku uses the Telemetry server to post information about the status of messages sent and received. We are running into a CORS error with `telemetry.status.im` because of a cross-origin request.

This PR adds a whitelists `lab.waku.org` where the js-waku dogfooding app is deployed.
