### PR TITLE
chore: drop constrain from wakuRequestResponse

### DIFF
--- a/lib/database/sql/000018_waku_req_res.up.sql
+++ b/lib/database/sql/000018_waku_req_res.up.sql
@@ -14,3 +14,15 @@ CREATE TABLE IF NOT EXISTS wakuRequestResponse (
 
 	CONSTRAINT messages_unique UNIQUE (peerId, messageHash)
 );
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'messages_unique'
+    ) THEN
+        ALTER TABLE wakuRequestResponse
+        DROP CONSTRAINT messages_unique;
+    END IF;
+END $$;


### PR DESCRIPTION
This PR remove unnecessary constrain from `wakuRequestResponse`. 
This is needed as some protocols or cases that we want to track do not have `messageHash` or `peerId` or unique pair of both and there might be no way of pushing unique data into the table. 