### PR TITLE
fix: use plain peerId for protocolStats

### DIFF
--- a/telemetry/server.go
+++ b/telemetry/server.go
@@ -2,9 +2,7 @@ package telemetry
 
 import (
 	"context"
-	"crypto/sha256"
 	"database/sql"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -186,9 +184,6 @@ func (s *Server) createProtocolStats(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer r.Body.Close()
-
-	peerIDHash := sha256.Sum256([]byte(protocolStats.PeerID))
-	protocolStats.PeerID = hex.EncodeToString(peerIDHash[:])
 
 	if err := protocolStats.Put(s.DB); err != nil {
 		s.logger.Error("failed to save protocol stats", zap.Error(err))


### PR DESCRIPTION
This PR removes hashing from `protocolStats` metrics. 

The PeerID is randomly generated on each start of the Status app and is not directly tied to identity. If we considered some malicious deeper analysis of collected data to try to guess users' identities I don't believe hashing peerId would prevent that - might slightly complicate things, but that's all.

So for the sake of simplicity and consistency I'd lean towards not hashing.

closes #41 