### PR TITLE
fix: remove id from generic metric, truncate duplicate log

### DIFF
--- a/lib/metrics/generic.go
+++ b/lib/metrics/generic.go
@@ -78,12 +78,6 @@ func (g *GenericMetric[T]) Process(ctx context.Context, db *sql.DB, errs *common
 		return result.Err()
 	}
 
-	var lastInsertId int
-	err = result.Scan(&lastInsertId)
-	if err != nil {
-		return err
-	}
-
 	if err := tx.Commit(); err != nil {
 		errs.Append(data.ID, fmt.Sprintf("Error committing transaction: %v", err))
 		return err

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -19,8 +19,8 @@ const (
 	MessageCheckFailureMetric      TelemetryType = "MessageCheckFailure"
 	DialFailureMetric              TelemetryType = "DialFailure"
 	StoreConfrimationErrorMetric   TelemetryType = "StoreConfrimationError"
-	MissedMessageMetric            TelemetryType = "MissedMessage"
-	MissedRelevantMessageMetric    TelemetryType = "MissedRelevantMessage"
+	MissedMessageMetric            TelemetryType = "MissedMessages"
+	MissedRelevantMessageMetric    TelemetryType = "MissedRelevantMessages"
 	MessageDeliveryConfirmedMetric TelemetryType = "MessageDeliveryConfirmed"
 )
 
@@ -175,7 +175,6 @@ type DialFailure struct {
 
 type MissedMessage struct {
 	TelemetryRecord
-	ID           int    `json:"id"`
 	ContentTopic string `json:"contentTopic"`
 	MessageHash  string `json:"messageHash"`
 	SentAt       int64  `json:"sentAt"`
@@ -184,7 +183,6 @@ type MissedMessage struct {
 
 type MissedRelevantMessage struct {
 	TelemetryRecord
-	ID           int    `json:"id"`
 	ContentTopic string `json:"contentTopic"`
 	MessageHash  string `json:"messageHash"`
 	SentAt       int64  `json:"sentAt"`
@@ -193,7 +191,6 @@ type MissedRelevantMessage struct {
 
 type MessageDeliveryConfirmed struct {
 	TelemetryRecord
-	ID          int    `json:"id"`
 	MessageHash string `json:"messageHash"`
 	Timestamp   int64  `json:"timestamp"`
 }

--- a/telemetry/server.go
+++ b/telemetry/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -241,6 +242,10 @@ func (s *Server) createWakuTelemetry(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			if err := pushFilter.Put(s.DB); err != nil {
+				if strings.Contains(err.Error(), "duplicate key value violates unique constraint") {
+					errorDetails.Append(data.Id, "Error saving lightpush/filter metric: Duplicate key value violates unique constraint")
+					continue
+				}
 				errorDetails.Append(data.Id, fmt.Sprintf("Error saving lightpush/filter metric: %v", err))
 				continue
 			}


### PR DESCRIPTION
The way generic metrics work, having the ID in the go type causes issues when writing to database (it tries to write to the ID field in postgres)